### PR TITLE
Final changes for AES GCM encryption streams

### DIFF
--- a/core/src/main/java/org/apache/iceberg/encryption/AesGcmInputFile.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/AesGcmInputFile.java
@@ -49,8 +49,8 @@ public class AesGcmInputFile implements InputFile {
   public SeekableInputStream newStream() {
     long ciphertextLength = sourceFile.getLength();
     Preconditions.checkState(
-        ciphertextLength >= Ciphers.GCM_STREAM_HEADER_LENGTH,
-        "Invalid encrypted stream: %d is shorter than the GCM stream header length",
+        ciphertextLength >= Ciphers.MIN_STREAM_LENGTH,
+        "Invalid encrypted stream: %d is shorter than the minimum possible stream length",
         ciphertextLength);
     return new AesGcmInputStream(sourceFile.newStream(), ciphertextLength, dataKey, fileAADPrefix);
   }

--- a/core/src/main/java/org/apache/iceberg/encryption/AesGcmInputStream.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/AesGcmInputStream.java
@@ -107,6 +107,10 @@ public class AesGcmInputStream extends SeekableInputStream {
   public int read(byte[] b, int off, int len) throws IOException {
     Preconditions.checkArgument(len >= 0, "Invalid read length: " + len);
 
+    if (currentPlainBlockIndex < 0) {
+      decryptBlock(0);
+    }
+
     if (available() <= 0 && len > 0) {
       throw new EOFException();
     }

--- a/core/src/main/java/org/apache/iceberg/encryption/AesGcmInputStream.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/AesGcmInputStream.java
@@ -30,6 +30,8 @@ public class AesGcmInputStream extends SeekableInputStream {
   private final SeekableInputStream sourceStream;
   private final byte[] fileAADPrefix;
   private final Ciphers.AesGcmDecryptor decryptor;
+  private final byte[] cipherBlockBuffer;
+  private final byte[] currentPlainBlock;
   private final long numBlocks;
   private final int lastCipherBlockSize;
   private final long plainStreamSize;
@@ -37,8 +39,6 @@ public class AesGcmInputStream extends SeekableInputStream {
 
   private long plainStreamPosition;
   private long currentPlainBlockIndex;
-  private byte[] cipherBlockBuffer;
-  private byte[] currentPlainBlock;
   private int currentPlainBlockSize;
 
   AesGcmInputStream(
@@ -183,16 +183,12 @@ public class AesGcmInputStream extends SeekableInputStream {
       return -1;
     }
 
-    int unsignedByte = singleByte[0] >= 0 ? singleByte[0] : 256 + singleByte[0];
-
-    return unsignedByte;
+    return singleByte[0] >= 0 ? singleByte[0] : 256 + singleByte[0];
   }
 
   @Override
   public void close() throws IOException {
     sourceStream.close();
-    this.currentPlainBlock = null;
-    this.cipherBlockBuffer = null;
   }
 
   private void decryptBlock(long blockIndex) throws IOException {

--- a/core/src/main/java/org/apache/iceberg/encryption/AesGcmOutputStream.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/AesGcmOutputStream.java
@@ -109,9 +109,7 @@ public class AesGcmOutputStream extends PositionOutputStream {
       writeHeader();
     }
 
-    if (positionInPlainBlock > 0) {
-      encryptAndWriteBlock();
-    }
+    encryptAndWriteBlock();
 
     targetStream.close();
   }
@@ -129,7 +127,7 @@ public class AesGcmOutputStream extends PositionOutputStream {
       throw new IOException("Cannot write block: exceeded Integer.MAX_VALUE blocks");
     }
 
-    if (positionInPlainBlock == 0) {
+    if (positionInPlainBlock == 0 && currentBlockIndex != 0) {
       return;
     }
 

--- a/core/src/main/java/org/apache/iceberg/encryption/Ciphers.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/Ciphers.java
@@ -54,20 +54,8 @@ public class Ciphers {
     private final byte[] nonce;
 
     public AesGcmEncryptor(byte[] keyBytes) {
-      Preconditions.checkArgument(keyBytes != null, "Key can't be null");
-      int keyLength = keyBytes.length;
-      Preconditions.checkArgument(
-          (keyLength == 16 || keyLength == 24 || keyLength == 32),
-          "Cannot use a key of length "
-              + keyLength
-              + " because AES only allows 16, 24 or 32 bytes");
-      this.aesKey = new SecretKeySpec(keyBytes, "AES");
-
-      try {
-        this.cipher = Cipher.getInstance("AES/GCM/NoPadding");
-      } catch (GeneralSecurityException e) {
-        throw new RuntimeException("Failed to create GCM cipher", e);
-      }
+      this.aesKey = newKey(keyBytes);
+      this.cipher = newCipher();
 
       this.randomGenerator = new SecureRandom();
       this.nonce = new byte[NONCE_LENGTH];
@@ -136,20 +124,8 @@ public class Ciphers {
     private final Cipher cipher;
 
     public AesGcmDecryptor(byte[] keyBytes) {
-      Preconditions.checkArgument(keyBytes != null, "Key can't be null");
-      int keyLength = keyBytes.length;
-      Preconditions.checkArgument(
-          (keyLength == 16 || keyLength == 24 || keyLength == 32),
-          "Cannot use a key of length "
-              + keyLength
-              + " because AES only allows 16, 24 or 32 bytes");
-      this.aesKey = new SecretKeySpec(keyBytes, "AES");
-
-      try {
-        this.cipher = Cipher.getInstance("AES/GCM/NoPadding");
-      } catch (GeneralSecurityException e) {
-        throw new RuntimeException("Failed to create GCM cipher", e);
-      }
+      this.aesKey = newKey(keyBytes);
+      this.cipher = newCipher();
     }
 
     public byte[] decrypt(byte[] ciphertext, byte[] aad) {
@@ -204,6 +180,24 @@ public class Ciphers {
       }
 
       return plaintextLength;
+    }
+  }
+
+  private static SecretKeySpec newKey(byte[] keyBytes) {
+    Preconditions.checkArgument(keyBytes != null, "Invalid key: null");
+    int keyLength = keyBytes.length;
+    Preconditions.checkArgument(
+        (keyLength == 16 || keyLength == 24 || keyLength == 32),
+        "Invalid key length: %s (must be 16, 24, or 32 bytes)",
+        keyLength);
+    return new SecretKeySpec(keyBytes, "AES");
+  }
+
+  private static Cipher newCipher() {
+    try {
+      return Cipher.getInstance("AES/GCM/NoPadding");
+    } catch (GeneralSecurityException e) {
+      throw new RuntimeException("Failed to create GCM cipher", e);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/encryption/Ciphers.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/Ciphers.java
@@ -45,6 +45,8 @@ public class Ciphers {
 
   private static final int GCM_TAG_LENGTH_BITS = 8 * GCM_TAG_LENGTH;
 
+  static final int MIN_STREAM_LENGTH = GCM_STREAM_HEADER_LENGTH + NONCE_LENGTH + GCM_TAG_LENGTH;
+
   private Ciphers() {}
 
   public static class AesGcmEncryptor {

--- a/core/src/main/java/org/apache/iceberg/encryption/Ciphers.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/Ciphers.java
@@ -80,7 +80,7 @@ public class Ciphers {
         int ciphertextOffset,
         byte[] aad) {
       Preconditions.checkArgument(
-          plaintextLength > 0, "Invalid plain text length: %s", plaintextLength);
+          plaintextLength >= 0, "Invalid plain text length: %s", plaintextLength);
       randomGenerator.nextBytes(nonce);
       int enciphered;
 
@@ -148,7 +148,7 @@ public class Ciphers {
         int plaintextOffset,
         byte[] aad) {
       Preconditions.checkState(
-          ciphertextLength - GCM_TAG_LENGTH - NONCE_LENGTH >= 1,
+          ciphertextLength - GCM_TAG_LENGTH - NONCE_LENGTH >= 0,
           "Cannot decrypt cipher text of length "
               + ciphertext.length
               + " because text must longer than GCM_TAG_LENGTH + NONCE_LENGTH bytes. Text may not be encrypted"


### PR DESCRIPTION
This implements the last few changes for the AES GCM encryption streams (https://github.com/apache/iceberg/pull/3231).

* Use final variables for reused cipher and plain byte arrays
* Validate that only one partial block can be written by the output stream (the last block)
* Remove unnecessary tracking of `streamPosition` in the output stream
* Remove some duplication in `Ciphers`
* Add separate tests to check AAD and nonce validation: bad AAD prefix, corrupt AAD, corrupt nonce, corrupt ciphertext
* Update empty file tests to validate the AAD

The main behavior change is that all files will write at least one cipher block. This is to ensure that the file AAD is validated even for empty files. Otherwise, an attacker could replace a metadata file with an empty file (with a valid header) and nothing would detect it.