### PR TITLE
Updates from review

### DIFF
--- a/api/src/main/java/org/apache/iceberg/encryption/EncryptedOutputFile.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/EncryptedOutputFile.java
@@ -39,7 +39,7 @@ public interface EncryptedOutputFile {
   EncryptionKeyMetadata keyMetadata();
 
   /** Underlying output file for native encryption. */
-  default OutputFile rawOutputFile() {
+  default OutputFile plainOutputFile() {
     throw new UnsupportedOperationException("Not implemented");
-  };
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -156,7 +156,7 @@ public class CatalogProperties {
 
   public static final String AUTH_SESSION_TIMEOUT_MS = "auth.session-timeout-ms";
   public static final long AUTH_SESSION_TIMEOUT_MS_DEFAULT = TimeUnit.HOURS.toMillis(1);
+
   public static final String ENCRYPTION_KMS_TYPE = "encryption.kms-type";
-  public static final String ENCRYPTION_KMS_CUSTOM_TYPE = "custom";
-  public static final String ENCRYPTION_KMS_CLIENT_IMPL = "encryption.kms.client-impl";
+  public static final String ENCRYPTION_KMS_IMPL = "encryption.kms-impl";
 }

--- a/core/src/main/java/org/apache/iceberg/encryption/EncryptedFiles.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/EncryptedFiles.java
@@ -57,9 +57,5 @@ public class EncryptedFiles {
         encryptedOutputFile, BaseEncryptionKeyMetadata.fromByteArray(keyMetadata));
   }
 
-  public static EncryptedOutputFile plainAsEncryptedOutput(OutputFile encryptingOutputFile) {
-    return new BaseEncryptedOutputFile(encryptingOutputFile, EncryptionKeyMetadata.empty());
-  }
-
   private EncryptedFiles() {}
 }

--- a/core/src/main/java/org/apache/iceberg/encryption/KeyMetadataDecoder.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/KeyMetadataDecoder.java
@@ -28,9 +28,9 @@ import org.apache.iceberg.avro.GenericAvroReader;
 import org.apache.iceberg.data.avro.RawDecoder;
 import org.apache.iceberg.relocated.com.google.common.collect.MapMaker;
 
-class KeyMetadataDecoder extends MessageDecoder.BaseDecoder<KeyMetadata> {
+class KeyMetadataDecoder extends MessageDecoder.BaseDecoder<StandardKeyMetadata> {
   private final org.apache.iceberg.Schema readSchema;
-  private final Map<Byte, RawDecoder<KeyMetadata>> decoders = new MapMaker().makeMap();
+  private final Map<Byte, RawDecoder<StandardKeyMetadata>> decoders = new MapMaker().makeMap();
 
   /**
    * Creates a new decoder that constructs key metadata instances described by schema version.
@@ -39,11 +39,11 @@ class KeyMetadataDecoder extends MessageDecoder.BaseDecoder<KeyMetadata> {
    * instances created by this class will are described by the expected schema.
    */
   KeyMetadataDecoder(byte readSchemaVersion) {
-    this.readSchema = KeyMetadata.supportedSchemaVersions().get(readSchemaVersion);
+    this.readSchema = StandardKeyMetadata.supportedSchemaVersions().get(readSchemaVersion);
   }
 
   @Override
-  public KeyMetadata decode(InputStream stream, KeyMetadata reuse) {
+  public StandardKeyMetadata decode(InputStream stream, StandardKeyMetadata reuse) {
     byte writeSchemaVersion;
 
     try {
@@ -56,14 +56,14 @@ class KeyMetadataDecoder extends MessageDecoder.BaseDecoder<KeyMetadata> {
       throw new RuntimeException("Version byte - end of stream reached");
     }
 
-    Schema writeSchema = KeyMetadata.supportedAvroSchemaVersions().get(writeSchemaVersion);
+    Schema writeSchema = StandardKeyMetadata.supportedAvroSchemaVersions().get(writeSchemaVersion);
 
     if (writeSchema == null) {
       throw new UnsupportedOperationException(
           "Cannot resolve schema for version: " + writeSchemaVersion);
     }
 
-    RawDecoder<KeyMetadata> decoder = decoders.get(writeSchemaVersion);
+    RawDecoder<StandardKeyMetadata> decoder = decoders.get(writeSchemaVersion);
 
     if (decoder == null) {
       decoder = new RawDecoder<>(readSchema, GenericAvroReader::create, writeSchema);

--- a/core/src/main/java/org/apache/iceberg/encryption/KeyMetadataEncoder.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/KeyMetadataEncoder.java
@@ -29,18 +29,18 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.message.MessageEncoder;
 import org.apache.iceberg.avro.GenericAvroWriter;
 
-class KeyMetadataEncoder implements MessageEncoder<KeyMetadata> {
+class KeyMetadataEncoder implements MessageEncoder<StandardKeyMetadata> {
   private static final ThreadLocal<BufferOutputStream> TEMP =
       ThreadLocal.withInitial(BufferOutputStream::new);
   private static final ThreadLocal<BinaryEncoder> ENCODER = new ThreadLocal<>();
 
   private final byte schemaVersion;
   private final boolean copyOutputBytes;
-  private final DatumWriter<KeyMetadata> writer;
+  private final DatumWriter<StandardKeyMetadata> writer;
 
   /**
-   * Creates a new {@link MessageEncoder} that will deconstruct {@link KeyMetadata} instances
-   * described by the schema version.
+   * Creates a new {@link MessageEncoder} that will deconstruct {@link StandardKeyMetadata}
+   * instances described by the schema version.
    *
    * <p>Buffers returned by {@code encode} are copied and will not be modified by future calls to
    * {@code encode}.
@@ -50,8 +50,8 @@ class KeyMetadataEncoder implements MessageEncoder<KeyMetadata> {
   }
 
   /**
-   * Creates a new {@link MessageEncoder} that will deconstruct {@link KeyMetadata} instances
-   * described by the schema version.
+   * Creates a new {@link MessageEncoder} that will deconstruct {@link StandardKeyMetadata}
+   * instances described by the schema version.
    *
    * <p>If {@code shouldCopy} is true, then buffers returned by {@code encode} are copied and will
    * not be modified by future calls to {@code encode}.
@@ -62,7 +62,7 @@ class KeyMetadataEncoder implements MessageEncoder<KeyMetadata> {
    * next call to {@code encode}.
    */
   KeyMetadataEncoder(byte schemaVersion, boolean shouldCopy) {
-    Schema writeSchema = KeyMetadata.supportedAvroSchemaVersions().get(schemaVersion);
+    Schema writeSchema = StandardKeyMetadata.supportedAvroSchemaVersions().get(schemaVersion);
 
     if (writeSchema == null) {
       throw new UnsupportedOperationException(
@@ -75,7 +75,7 @@ class KeyMetadataEncoder implements MessageEncoder<KeyMetadata> {
   }
 
   @Override
-  public ByteBuffer encode(KeyMetadata datum) throws IOException {
+  public ByteBuffer encode(StandardKeyMetadata datum) throws IOException {
     BufferOutputStream temp = TEMP.get();
     temp.reset();
     temp.write(schemaVersion);
@@ -89,7 +89,7 @@ class KeyMetadataEncoder implements MessageEncoder<KeyMetadata> {
   }
 
   @Override
-  public void encode(KeyMetadata datum, OutputStream stream) throws IOException {
+  public void encode(StandardKeyMetadata datum, OutputStream stream) throws IOException {
     BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(stream, ENCODER.get());
     ENCODER.set(encoder);
     writer.write(datum, encoder);

--- a/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
@@ -23,6 +23,7 @@ import java.security.SecureRandom;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.util.ByteBuffers;
@@ -34,38 +35,6 @@ public class StandardEncryptionManager implements EncryptionManager {
 
   private transient volatile SecureRandom lazyRNG = null;
 
-  class StandardEncryptedOutputFile implements EncryptedOutputFile {
-
-    private final OutputFile encryptingOutputFile;
-
-    private final EncryptionKeyMetadata keyMetadata;
-    private final OutputFile rawOutputFile;
-
-    StandardEncryptedOutputFile(
-        OutputFile encryptingOutputFile,
-        EncryptionKeyMetadata keyMetadata,
-        OutputFile rawOutputFile) {
-      this.encryptingOutputFile = encryptingOutputFile;
-      this.keyMetadata = keyMetadata;
-      this.rawOutputFile = rawOutputFile;
-    }
-
-    @Override
-    public OutputFile encryptingOutputFile() {
-      return encryptingOutputFile;
-    }
-
-    @Override
-    public EncryptionKeyMetadata keyMetadata() {
-      return keyMetadata;
-    }
-
-    @Override
-    public OutputFile rawOutputFile() {
-      return rawOutputFile;
-    }
-  }
-
   /**
    * @param tableKeyId table encryption key id
    * @param dataKeyLength length of data encryption key (16/24/32 bytes)
@@ -74,6 +43,10 @@ public class StandardEncryptionManager implements EncryptionManager {
   public StandardEncryptionManager(
       String tableKeyId, int dataKeyLength, KeyManagementClient kmsClient) {
     Preconditions.checkNotNull(tableKeyId, "Invalid encryption key ID: null");
+    Preconditions.checkArgument(
+        dataKeyLength == 16 || dataKeyLength == 24 || dataKeyLength == 32,
+        "Invalid data key length: %s (must be 16, 24, or 32)",
+        dataKeyLength);
     Preconditions.checkNotNull(kmsClient, "Invalid KMS client: null");
     this.tableKeyId = tableKeyId;
     this.kmsClient = kmsClient;
@@ -81,39 +54,20 @@ public class StandardEncryptionManager implements EncryptionManager {
   }
 
   @Override
-  public EncryptedOutputFile encrypt(OutputFile rawOutput) {
-    ByteBuffer fileDek = ByteBuffer.allocate(dataKeyLength);
-    workerRNG().nextBytes(fileDek.array());
-
-    ByteBuffer aadPrefix = ByteBuffer.allocate(TableProperties.ENCRYPTION_AAD_LENGTH_DEFAULT);
-    workerRNG().nextBytes(aadPrefix.array());
-
-    KeyMetadata encryptionMetadata = new KeyMetadata(fileDek, aadPrefix);
-
-    return new StandardEncryptedOutputFile(
-        new AesGcmOutputFile(rawOutput, fileDek.array(), aadPrefix.array()),
-        encryptionMetadata,
-        rawOutput);
+  public EncryptedOutputFile encrypt(OutputFile plainOutput) {
+    return new StandardEncryptedOutputFile(plainOutput, dataKeyLength);
   }
 
   @Override
   public InputFile decrypt(EncryptedInputFile encrypted) {
-    KeyMetadata keyMetadata = KeyMetadata.castOrParse(encrypted.keyMetadata());
-
-    byte[] fileDek = ByteBuffers.toByteArray(keyMetadata.encryptionKey());
-    byte[] aadPrefix = ByteBuffers.toByteArray(keyMetadata.aadPrefix());
-
-    return new AesGcmInputFile(encrypted.encryptedInputFile(), fileDek, aadPrefix);
+    // this input file will lazily parse key metadata in case the file is not an AES GCM stream.
+    return new StandardDecryptedInputFile(encrypted);
   }
 
   @Override
   public Iterable<InputFile> decrypt(Iterable<EncryptedInputFile> encrypted) {
     // Bulk decrypt is only applied to data files. Returning source input files for parquet.
-    return Iterables.transform(encrypted, this::getSourceFile);
-  }
-
-  private InputFile getSourceFile(EncryptedInputFile encryptedFile) {
-    return encryptedFile.encryptedInputFile();
+    return Iterables.transform(encrypted, this::decrypt);
   }
 
   private SecureRandom workerRNG() {
@@ -126,7 +80,8 @@ public class StandardEncryptionManager implements EncryptionManager {
 
   public ByteBuffer wrapKey(ByteBuffer secretKey) {
     if (kmsClient == null) {
-      throw new IllegalStateException("Null KmsClient. WrapKey can't be called from workers");
+      throw new IllegalStateException(
+          "Cannot wrap key after called after serialization (missing KMS client)");
     }
 
     return kmsClient.wrapKey(secretKey, tableKeyId);
@@ -134,9 +89,105 @@ public class StandardEncryptionManager implements EncryptionManager {
 
   public ByteBuffer unwrapKey(ByteBuffer wrappedSecretKey) {
     if (kmsClient == null) {
-      throw new IllegalStateException("Null KmsClient. UnwrapKey can't be called from workers");
+      throw new IllegalStateException(
+          "Cannot wrap key after called after serialization (missing KMS client)");
     }
 
     return kmsClient.unwrapKey(wrappedSecretKey, tableKeyId);
+  }
+
+  private class StandardEncryptedOutputFile implements EncryptedOutputFile {
+    private final OutputFile plainOutputFile;
+    private final int dataKeyLength;
+    private StandardKeyMetadata lazyKeyMetadata = null;
+    private OutputFile lazyEncryptingOutputFile = null;
+
+    StandardEncryptedOutputFile(OutputFile plainOutputFile, int dataKeyLength) {
+      this.plainOutputFile = plainOutputFile;
+      this.dataKeyLength = dataKeyLength;
+    }
+
+    @Override
+    public StandardKeyMetadata keyMetadata() {
+      if (null == lazyKeyMetadata) {
+        byte[] fileDek = new byte[dataKeyLength];
+        workerRNG().nextBytes(fileDek);
+
+        byte[] aadPrefix = new byte[TableProperties.ENCRYPTION_AAD_LENGTH_DEFAULT];
+        workerRNG().nextBytes(aadPrefix);
+
+        this.lazyKeyMetadata = new StandardKeyMetadata(fileDek, aadPrefix);
+      }
+
+      return lazyKeyMetadata;
+    }
+
+    @Override
+    public OutputFile encryptingOutputFile() {
+      if (null == lazyEncryptingOutputFile) {
+        this.lazyEncryptingOutputFile =
+            new AesGcmOutputFile(
+                plainOutputFile,
+                ByteBuffers.toByteArray(keyMetadata().encryptionKey()),
+                ByteBuffers.toByteArray(keyMetadata().aadPrefix()));
+      }
+
+      return lazyEncryptingOutputFile;
+    }
+
+    @Override
+    public OutputFile plainOutputFile() {
+      return plainOutputFile;
+    }
+  }
+
+  private static class StandardDecryptedInputFile implements InputFile {
+    private final EncryptedInputFile encryptedInputFile;
+    private StandardKeyMetadata lazyKeyMetadata = null;
+    private AesGcmInputFile lazyDecryptedInputFile = null;
+
+    private StandardDecryptedInputFile(EncryptedInputFile encryptedInputFile) {
+      this.encryptedInputFile = encryptedInputFile;
+    }
+
+    private StandardKeyMetadata keyMetadata() {
+      if (null == lazyKeyMetadata) {
+        this.lazyKeyMetadata = StandardKeyMetadata.castOrParse(encryptedInputFile.keyMetadata());
+      }
+
+      return lazyKeyMetadata;
+    }
+
+    private AesGcmInputFile decrypted() {
+      if (null == lazyDecryptedInputFile) {
+        this.lazyDecryptedInputFile =
+            new AesGcmInputFile(
+                encryptedInputFile.encryptedInputFile(),
+                ByteBuffers.toByteArray(keyMetadata().encryptionKey()),
+                ByteBuffers.toByteArray(keyMetadata().aadPrefix()));
+      }
+
+      return lazyDecryptedInputFile;
+    }
+
+    @Override
+    public long getLength() {
+      return decrypted().getLength();
+    }
+
+    @Override
+    public SeekableInputStream newStream() {
+      return decrypted().newStream();
+    }
+
+    @Override
+    public String location() {
+      return decrypted().location();
+    }
+
+    @Override
+    public boolean exists() {
+      return decrypted().exists();
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/encryption/StandardKeyMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardKeyMetadata.java
@@ -31,14 +31,14 @@ import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 
-class KeyMetadata implements EncryptionKeyMetadata, IndexedRecord {
+class StandardKeyMetadata implements EncryptionKeyMetadata, IndexedRecord {
   private static final byte V1 = 1;
   private static final Schema SCHEMA_V1 =
       new Schema(
           required(0, "encryption_key", Types.BinaryType.get()),
           optional(1, "aad_prefix", Types.BinaryType.get()));
   private static final org.apache.avro.Schema AVRO_SCHEMA_V1 =
-      AvroSchemaUtil.convert(SCHEMA_V1, KeyMetadata.class.getCanonicalName());
+      AvroSchemaUtil.convert(SCHEMA_V1, StandardKeyMetadata.class.getCanonicalName());
 
   private static final Map<Byte, Schema> schemaVersions = ImmutableMap.of(V1, SCHEMA_V1);
   private static final Map<Byte, org.apache.avro.Schema> avroSchemaVersions =
@@ -52,9 +52,14 @@ class KeyMetadata implements EncryptionKeyMetadata, IndexedRecord {
   private org.apache.avro.Schema avroSchema;
 
   /** Used by Avro reflection to instantiate this class * */
-  KeyMetadata() {}
+  StandardKeyMetadata() {}
 
-  KeyMetadata(ByteBuffer encryptionKey, ByteBuffer aadPrefix) {
+  StandardKeyMetadata(byte[] key, byte[] aad) {
+    this.encryptionKey = ByteBuffer.wrap(key);
+    this.aadPrefix = ByteBuffer.wrap(aad);
+  }
+
+  private StandardKeyMetadata(ByteBuffer encryptionKey, ByteBuffer aadPrefix) {
     this.encryptionKey = encryptionKey;
     this.aadPrefix = aadPrefix;
     this.avroSchema = AVRO_SCHEMA_V1;
@@ -76,9 +81,9 @@ class KeyMetadata implements EncryptionKeyMetadata, IndexedRecord {
     return aadPrefix;
   }
 
-  static KeyMetadata castOrParse(EncryptionKeyMetadata keyMetadata) {
-    if (keyMetadata instanceof KeyMetadata) {
-      return (KeyMetadata) keyMetadata;
+  static StandardKeyMetadata castOrParse(EncryptionKeyMetadata keyMetadata) {
+    if (keyMetadata instanceof StandardKeyMetadata) {
+      return (StandardKeyMetadata) keyMetadata;
     }
 
     ByteBuffer kmBuffer = keyMetadata.buffer();
@@ -90,7 +95,7 @@ class KeyMetadata implements EncryptionKeyMetadata, IndexedRecord {
     return parse(kmBuffer);
   }
 
-  static KeyMetadata parse(ByteBuffer buffer) {
+  static StandardKeyMetadata parse(ByteBuffer buffer) {
     try {
       return KEY_METADATA_DECODER.decode(buffer);
     } catch (IOException e) {
@@ -109,8 +114,7 @@ class KeyMetadata implements EncryptionKeyMetadata, IndexedRecord {
 
   @Override
   public EncryptionKeyMetadata copy() {
-    KeyMetadata metadata = new KeyMetadata(encryptionKey(), aadPrefix());
-    return metadata;
+    return new StandardKeyMetadata(encryptionKey(), aadPrefix());
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/encryption/TestStandardKeyMetadataParser.java
+++ b/core/src/test/java/org/apache/iceberg/encryption/TestStandardKeyMetadataParser.java
@@ -24,16 +24,17 @@ import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestKeyMetadataParser {
+public class TestStandardKeyMetadataParser {
 
   @Test
   public void testParser() {
     ByteBuffer encryptionKey = ByteBuffer.wrap("0123456789012345".getBytes(StandardCharsets.UTF_8));
     ByteBuffer aadPrefix = ByteBuffer.wrap("1234567890123456".getBytes(StandardCharsets.UTF_8));
-    KeyMetadata metadata = new KeyMetadata(encryptionKey, aadPrefix);
+    StandardKeyMetadata metadata =
+        new StandardKeyMetadata(encryptionKey.array(), aadPrefix.array());
     ByteBuffer serialized = metadata.buffer();
 
-    KeyMetadata parsedMetadata = KeyMetadata.parse(serialized);
+    StandardKeyMetadata parsedMetadata = StandardKeyMetadata.parse(serialized);
     Assert.assertEquals(parsedMetadata.encryptionKey(), encryptionKey);
     Assert.assertEquals(parsedMetadata.aadPrefix(), aadPrefix);
   }
@@ -41,7 +42,7 @@ public class TestKeyMetadataParser {
   @Test
   public void testUnsupportedVersion() {
     ByteBuffer badBuffer = ByteBuffer.wrap(new byte[] {0x02});
-    Assertions.assertThatThrownBy(() -> KeyMetadata.parse(badBuffer))
+    Assertions.assertThatThrownBy(() -> StandardKeyMetadata.parse(badBuffer))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage("Cannot resolve schema for version: 2");
   }


### PR DESCRIPTION
This set of changes updates https://github.com/apache/iceberg/pull/6884 with review comments. Major changes are:
* Rename `rawOutputFile` to `plainOutputFile`
* Rename `KeyMetadata` to `StandardKeyMetadata`
* Remove `custom` KMS type, replace with simpler logic to determine impl or type
* Refactor the encrypting input and output files to create `AesGcm*` files lazily
* Remove unused methods