### PR TITLE
Add native subclasses for InputFile and OutputFile to simplify.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -95,7 +95,7 @@ public class Avro {
   public static WriteBuilder write(EncryptedOutputFile file) {
     Preconditions.checkState(
         file.keyMetadata() == null || file.keyMetadata() == EncryptionKeyMetadata.EMPTY,
-        "Currenty, encryption of data files in Avro format is not supported");
+        "Avro encryption is not supported");
     return new WriteBuilder(file.encryptingOutputFile());
   }
 
@@ -283,7 +283,7 @@ public class Avro {
   public static DataWriteBuilder writeData(EncryptedOutputFile file) {
     Preconditions.checkState(
         file.keyMetadata() == null || file.keyMetadata() == EncryptionKeyMetadata.EMPTY,
-        "Currenty, encryption of data files in Avro format is not supported");
+        "Avro encryption is not supported");
     return new DataWriteBuilder(file.encryptingOutputFile());
   }
 
@@ -386,7 +386,7 @@ public class Avro {
   public static DeleteWriteBuilder writeDeletes(EncryptedOutputFile file) {
     Preconditions.checkState(
         file.keyMetadata() == null || file.keyMetadata() == EncryptionKeyMetadata.EMPTY,
-        "Currenty, encryption of delete files in Avro format is not supported");
+        "Avro encryption is not supported");
     return new DeleteWriteBuilder(file.encryptingOutputFile());
   }
 

--- a/core/src/main/java/org/apache/iceberg/encryption/EncryptionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/EncryptionUtil.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.encryption;
 
 import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
-import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.io.OutputFile;
@@ -81,14 +80,6 @@ public class EncryptionUtil {
       return PlaintextEncryptionManager.instance();
     }
 
-    String fileFormat =
-        PropertyUtil.propertyAsString(
-            tableProperties,
-            TableProperties.DEFAULT_FILE_FORMAT,
-            TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
-
-    boolean nativeDataEncryption = (FileFormat.fromString(fileFormat) == FileFormat.PARQUET);
-
     int dataKeyLength =
         PropertyUtil.propertyAsInt(
             tableProperties,
@@ -100,8 +91,7 @@ public class EncryptionUtil {
         "Invalid data key length: %s (must be 16, 24, or 32)",
         dataKeyLength);
 
-    return new StandardEncryptionManager(
-        tableKeyId, dataKeyLength, kmsClient, nativeDataEncryption);
+    return new StandardEncryptionManager(tableKeyId, dataKeyLength, kmsClient);
   }
 
   public static EncryptedOutputFile plainAsEncryptedOutput(OutputFile encryptingOutputFile) {

--- a/core/src/main/java/org/apache/iceberg/encryption/NativeEncryptionInputFile.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/NativeEncryptionInputFile.java
@@ -18,23 +18,10 @@
  */
 package org.apache.iceberg.encryption;
 
-import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.InputFile;
 
-/**
- * Thin wrapper around a {@link OutputFile} that is encrypting bytes written to the underlying file
- * system, via an encryption key that is symbolized by the enclosed {@link EncryptionKeyMetadata}.
- *
- * <p>The {@link EncryptionManager} returns instances of these when passed output files that should
- * be encrypted as they are being written to the backing file system.
- */
-public interface EncryptedOutputFile {
-
-  /** An OutputFile instance that encrypts the bytes that are written to its output streams. */
-  OutputFile encryptingOutputFile();
-
-  /**
-   * Metadata about the encryption key that is being used to encrypt the associated {@link
-   * #encryptingOutputFile()}.
-   */
-  EncryptionKeyMetadata keyMetadata();
+/** An {@link EncryptedInputFile} that can be used for format-native encryption. */
+public interface NativeEncryptionInputFile extends EncryptedInputFile, InputFile {
+  @Override
+  NativeEncryptionKeyMetadata keyMetadata();
 }

--- a/core/src/main/java/org/apache/iceberg/encryption/NativeEncryptionKeyMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/NativeEncryptionKeyMetadata.java
@@ -18,23 +18,13 @@
  */
 package org.apache.iceberg.encryption;
 
-import org.apache.iceberg.io.OutputFile;
+import java.nio.ByteBuffer;
 
-/**
- * Thin wrapper around a {@link OutputFile} that is encrypting bytes written to the underlying file
- * system, via an encryption key that is symbolized by the enclosed {@link EncryptionKeyMetadata}.
- *
- * <p>The {@link EncryptionManager} returns instances of these when passed output files that should
- * be encrypted as they are being written to the backing file system.
- */
-public interface EncryptedOutputFile {
+/** {@link EncryptionKeyMetadata} for use with format-native encryption. */
+public interface NativeEncryptionKeyMetadata extends EncryptionKeyMetadata {
+  /** Encryption key as a {@link ByteBuffer} */
+  ByteBuffer encryptionKey();
 
-  /** An OutputFile instance that encrypts the bytes that are written to its output streams. */
-  OutputFile encryptingOutputFile();
-
-  /**
-   * Metadata about the encryption key that is being used to encrypt the associated {@link
-   * #encryptingOutputFile()}.
-   */
-  EncryptionKeyMetadata keyMetadata();
+  /** Additional authentication data as a {@link ByteBuffer} */
+  ByteBuffer aadPrefix();
 }

--- a/core/src/main/java/org/apache/iceberg/encryption/NativeEncryptionOutputFile.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/NativeEncryptionOutputFile.java
@@ -20,21 +20,11 @@ package org.apache.iceberg.encryption;
 
 import org.apache.iceberg.io.OutputFile;
 
-/**
- * Thin wrapper around a {@link OutputFile} that is encrypting bytes written to the underlying file
- * system, via an encryption key that is symbolized by the enclosed {@link EncryptionKeyMetadata}.
- *
- * <p>The {@link EncryptionManager} returns instances of these when passed output files that should
- * be encrypted as they are being written to the backing file system.
- */
-public interface EncryptedOutputFile {
+/** An {@link EncryptedOutputFile} that can be used for format-native encryption. */
+public interface NativeEncryptionOutputFile extends EncryptedOutputFile {
+  @Override
+  NativeEncryptionKeyMetadata keyMetadata();
 
-  /** An OutputFile instance that encrypts the bytes that are written to its output streams. */
-  OutputFile encryptingOutputFile();
-
-  /**
-   * Metadata about the encryption key that is being used to encrypt the associated {@link
-   * #encryptingOutputFile()}.
-   */
-  EncryptionKeyMetadata keyMetadata();
+  /** An {@link OutputFile} instance for the underlying (plaintext) output stream. */
+  OutputFile plainOutputFile();
 }

--- a/core/src/main/java/org/apache/iceberg/encryption/StandardKeyMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardKeyMetadata.java
@@ -31,7 +31,7 @@ import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 
-public class StandardKeyMetadata implements EncryptionKeyMetadata, IndexedRecord {
+class StandardKeyMetadata implements NativeEncryptionKeyMetadata, IndexedRecord {
   private static final byte V1 = 1;
   private static final Schema SCHEMA_V1 =
       new Schema(
@@ -73,10 +73,12 @@ public class StandardKeyMetadata implements EncryptionKeyMetadata, IndexedRecord
     return avroSchemaVersions;
   }
 
+  @Override
   public ByteBuffer encryptionKey() {
     return encryptionKey;
   }
 
+  @Override
   public ByteBuffer aadPrefix() {
     return aadPrefix;
   }
@@ -95,7 +97,7 @@ public class StandardKeyMetadata implements EncryptionKeyMetadata, IndexedRecord
     return parse(kmBuffer);
   }
 
-  public static StandardKeyMetadata parse(ByteBuffer buffer) {
+  static StandardKeyMetadata parse(ByteBuffer buffer) {
     try {
       return KEY_METADATA_DECODER.decode(buffer);
     } catch (IOException e) {

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -36,7 +36,6 @@ import org.apache.iceberg.data.parquet.GenericParquetReaders;
 import org.apache.iceberg.deletes.DeleteCounter;
 import org.apache.iceberg.deletes.Deletes;
 import org.apache.iceberg.deletes.PositionDeleteIndex;
-import org.apache.iceberg.encryption.StandardKeyMetadata;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
@@ -280,12 +279,6 @@ public abstract class DeleteFilter<T> {
 
         if (deleteFile.content() == FileContent.POSITION_DELETES) {
           builder.filter(Expressions.equal(MetadataColumns.DELETE_FILE_PATH.name(), filePath));
-        }
-
-        if (deleteFile.keyMetadata() != null) {
-          StandardKeyMetadata keyMetadata = StandardKeyMetadata.parse(deleteFile.keyMetadata());
-          builder.withFileEncryptionKey(keyMetadata.encryptionKey());
-          builder.withAADPrefix(keyMetadata.aadPrefix());
         }
 
         return builder.build();

--- a/data/src/main/java/org/apache/iceberg/data/GenericReader.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericReader.java
@@ -29,7 +29,6 @@ import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.data.avro.DataReader;
 import org.apache.iceberg.data.orc.GenericOrcReader;
 import org.apache.iceberg.data.parquet.GenericParquetReaders;
-import org.apache.iceberg.encryption.StandardKeyMetadata;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -125,12 +124,6 @@ class GenericReader implements Serializable {
 
         if (reuseContainers) {
           parquet.reuseContainers();
-        }
-
-        if (task.file().keyMetadata() != null) {
-          StandardKeyMetadata keyMetadata = StandardKeyMetadata.parse(task.file().keyMetadata());
-          parquet.withFileEncryptionKey(keyMetadata.encryptionKey());
-          parquet.withAADPrefix(keyMetadata.aadPrefix());
         }
 
         return parquet.build();

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -56,8 +56,8 @@ import org.apache.iceberg.data.InternalRecordWrapper;
 import org.apache.iceberg.data.avro.DataReader;
 import org.apache.iceberg.data.orc.GenericOrcReader;
 import org.apache.iceberg.data.parquet.GenericParquetReaders;
+import org.apache.iceberg.encryption.EncryptedFiles;
 import org.apache.iceberg.encryption.EncryptionManager;
-import org.apache.iceberg.encryption.StandardKeyMetadata;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -302,7 +302,10 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
 
     private CloseableIterable<T> openTask(FileScanTask currentTask, Schema readSchema) {
       DataFile file = currentTask.file();
-      InputFile inputFile = io.newInputFile(file.path().toString());
+      InputFile inputFile =
+          encryptionManager.decrypt(
+              EncryptedFiles.encryptedInput(
+                  io.newInputFile(file.path().toString()), file.keyMetadata()));
 
       CloseableIterable<T> iterable;
       switch (file.format()) {
@@ -416,13 +419,6 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
           if (nameMapping != null) {
             parquetReadBuilder.withNameMapping(NameMappingParser.fromJson(nameMapping));
           }
-
-          if (task.file().keyMetadata() != null) {
-            StandardKeyMetadata keyMetadata = StandardKeyMetadata.parse(task.file().keyMetadata());
-            parquetReadBuilder.withFileEncryptionKey(keyMetadata.encryptionKey());
-            parquetReadBuilder.withAADPrefix(keyMetadata.aadPrefix());
-          }
-
           parquetReadBuilder.createReaderFunc(
               fileSchema ->
                   GenericParquetReaders.buildReader(

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -65,6 +65,8 @@ import org.apache.iceberg.deletes.EqualityDeleteWriter;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.encryption.EncryptionKeyMetadata;
+import org.apache.iceberg.encryption.NativeEncryptionInputFile;
+import org.apache.iceberg.encryption.NativeEncryptionOutputFile;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.hadoop.HadoopInputFile;
@@ -104,8 +106,7 @@ public class ORC {
 
   public static WriteBuilder write(EncryptedOutputFile file) {
     Preconditions.checkState(
-        file.keyMetadata() == null || file.keyMetadata() == EncryptionKeyMetadata.EMPTY,
-        "Currenty, encryption of data files in ORC format is not supported");
+        !(file instanceof NativeEncryptionOutputFile), "Native ORC encryption is not supported");
     return new WriteBuilder(file.encryptingOutputFile());
   }
 
@@ -392,8 +393,7 @@ public class ORC {
 
   public static DataWriteBuilder writeData(EncryptedOutputFile file) {
     Preconditions.checkState(
-        file.keyMetadata() == null || file.keyMetadata() == EncryptionKeyMetadata.EMPTY,
-        "Currenty, encryption of data files in ORC format is not supported");
+        !(file instanceof NativeEncryptionOutputFile), "Native ORC encryption is not supported");
     return new DataWriteBuilder(file.encryptingOutputFile());
   }
 
@@ -496,8 +496,7 @@ public class ORC {
 
   public static DeleteWriteBuilder writeDeletes(EncryptedOutputFile file) {
     Preconditions.checkState(
-        file.keyMetadata() == null || file.keyMetadata() == EncryptionKeyMetadata.EMPTY,
-        "Currenty, encryption of delete files in ORC format is not supported");
+        !(file instanceof NativeEncryptionOutputFile), "Native ORC encryption is not supported");
     return new DeleteWriteBuilder(file.encryptingOutputFile());
   }
 
@@ -679,6 +678,9 @@ public class ORC {
   }
 
   public static ReadBuilder read(InputFile file) {
+    Preconditions.checkState(
+        !(file instanceof NativeEncryptionInputFile), "Native ORC encryption is not supported");
+
     return new ReadBuilder(file);
   }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.spark.source;
 
-import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.FileFormat;
@@ -27,15 +26,11 @@ import org.apache.iceberg.ScanTask;
 import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.encryption.EncryptedFiles;
-import org.apache.iceberg.encryption.EncryptedInputFile;
-import org.apache.iceberg.encryption.StandardKeyMetadata;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.Parquet;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.data.vectorized.VectorizedSparkOrcReaders;
 import org.apache.iceberg.spark.data.vectorized.VectorizedSparkParquetReaders;
@@ -58,7 +53,6 @@ abstract class BaseBatchReader<T extends ScanTask> extends BaseReader<ColumnarBa
 
   protected CloseableIterable<ColumnarBatch> newBatchIterable(
       InputFile inputFile,
-      ByteBuffer keyMetadata,
       FileFormat format,
       long start,
       long length,
@@ -67,17 +61,9 @@ abstract class BaseBatchReader<T extends ScanTask> extends BaseReader<ColumnarBa
       SparkDeleteFilter deleteFilter) {
     switch (format) {
       case PARQUET:
-        return newParquetIterable(
-            EncryptedFiles.encryptedInput(inputFile, keyMetadata),
-            start,
-            length,
-            residual,
-            idToConstant,
-            deleteFilter);
+        return newParquetIterable(inputFile, start, length, residual, idToConstant, deleteFilter);
 
       case ORC:
-        Preconditions.checkState(
-            keyMetadata == null, "Encryption currently not supported with ORC format");
         return newOrcIterable(inputFile, start, length, residual, idToConstant);
 
       default:
@@ -87,7 +73,7 @@ abstract class BaseBatchReader<T extends ScanTask> extends BaseReader<ColumnarBa
   }
 
   private CloseableIterable<ColumnarBatch> newParquetIterable(
-      EncryptedInputFile inputFile,
+      InputFile inputFile,
       long start,
       long length,
       Expression residual,
@@ -96,15 +82,7 @@ abstract class BaseBatchReader<T extends ScanTask> extends BaseReader<ColumnarBa
     // get required schema if there are deletes
     Schema requiredSchema = deleteFilter != null ? deleteFilter.requiredSchema() : expectedSchema();
 
-    ByteBuffer fileEncryptionKey = null;
-    ByteBuffer aadPrefix = null;
-    if (inputFile.keyMetadata() != null && inputFile.keyMetadata().buffer() != null) {
-      StandardKeyMetadata keyMetadata = StandardKeyMetadata.parse(inputFile.keyMetadata().buffer());
-      fileEncryptionKey = keyMetadata.encryptionKey();
-      aadPrefix = keyMetadata.aadPrefix();
-    }
-
-    return Parquet.read(inputFile.encryptedInputFile())
+    return Parquet.read(inputFile)
         .project(requiredSchema)
         .split(start, length)
         .createBatchedReaderFunc(
@@ -119,8 +97,6 @@ abstract class BaseBatchReader<T extends ScanTask> extends BaseReader<ColumnarBa
         // read performance as every batch read doesn't have to pay the cost of allocating memory.
         .reuseContainers()
         .withNameMapping(nameMapping())
-        .withFileEncryptionKey(fileEncryptionKey)
-        .withAADPrefix(aadPrefix)
         .build();
   }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -100,7 +100,6 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
 
     return newBatchIterable(
             inputFile,
-            task.file().keyMetadata(),
             task.file().format(),
             task.start(),
             task.length(),

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
@@ -133,7 +133,6 @@ class ChangelogRowReader extends BaseRowReader<ChangelogScanTask>
     Preconditions.checkNotNull(location, "Could not find InputFile");
     return newIterable(
         location,
-        task.file().keyMetadata(),
         task.file().format(),
         task.start(),
         task.length(),

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/PositionDeletesRowReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/PositionDeletesRowReader.java
@@ -92,7 +92,6 @@ class PositionDeletesRowReader extends BaseRowReader<PositionDeletesScanTask>
 
     return newIterable(
             inputFile,
-            task.file().keyMetadata(),
             task.file().format(),
             task.start(),
             task.length(),

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -105,7 +105,6 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
           inputFile, "Could not find InputFile associated with FileScanTask");
       return newIterable(
           inputFile,
-          task.file().keyMetadata(),
           task.file().format(),
           task.start(),
           task.length(),

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkAppenderFactory.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkAppenderFactory.java
@@ -162,8 +162,8 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
   }
 
   @Override
-  public FileAppender<InternalRow> newAppender(OutputFile outputFile, FileFormat format) {
-    return newAppender(EncryptionUtil.plainAsEncryptedOutput(outputFile), format);
+  public FileAppender<InternalRow> newAppender(OutputFile file, FileFormat fileFormat) {
+    return newAppender(EncryptionUtil.plainAsEncryptedOutput(file), fileFormat);
   }
 
   @Override


### PR DESCRIPTION
This is an update to https://github.com/apache/iceberg/pull/9359 that simplifies the read path and addresses review items.

This introduces `NativeEncryptionInputFile` to solve problems in the read path. Specifically the encryption manager needed to know whether to decrypt or return the underlying input file, but that depends on the file format and whether that format is capable of native encryption. In addition, the read path also needed to know whether to configure native encryption, which was a separate choice. And I think having a separate encryption choice would also have broken existing encryption managers that handle Parquet files with encrypting streams.

Instead, this uses a new `InputFile` type to signal that native encryption should be used if possible and to carry the encryption key. Then the format helpers (`Avro`, `Parquet`, and `ORC`) are responsible for either using the encrypting stream (Avro) or applying native encryption (Parquet and ORC).

I considered other approaches here, but this was the cleanest because most others required separate handling for encryption keys and didn't cover all paths -- notably missing the Arrow readers. By using the same `InputFile` everywhere, this requires fewer changes to Spark and Flink readers and should work everywhere that the encryption manager is used.