### PR TITLE
Cache unwrapped encryption keys

### DIFF
--- a/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
@@ -23,7 +23,6 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.Base64;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -141,6 +140,10 @@ public class StandardEncryptionManager implements EncryptionManager {
     return lazyRNG;
   }
 
+  /**
+   * @deprecated will be removed in 1.8.0; use {@link #currentSnapshotKeyId()} instead.
+   */
+  @Deprecated
   public ByteBuffer wrapKey(ByteBuffer secretKey) {
     if (keyData == null) {
       throw new IllegalStateException(
@@ -150,6 +153,10 @@ public class StandardEncryptionManager implements EncryptionManager {
     return keyData.kmsClient.wrapKey(secretKey, tableKeyId);
   }
 
+  /**
+   * @deprecated will be removed in 1.8.0; use {@link #unwrapKey(String)}} instead.
+   */
+  @Deprecated
   public ByteBuffer unwrapKey(ByteBuffer wrappedSecretKey) {
     if (keyData == null) {
       throw new IllegalStateException("Cannot unwrap key after serialization (missing KMS client)");
@@ -178,14 +185,6 @@ public class StandardEncryptionManager implements EncryptionManager {
     }
 
     return keyData.unwrappedKeyCache.get(keyData.encryptionKeys.get(keyId).wrappedKey());
-  }
-
-  Collection<WrappedEncryptionKey> keys() {
-    if (keyData == null) {
-      throw new IllegalStateException("Cannot return the current keys after serialization");
-    }
-
-    return keyData.encryptionKeys.values();
   }
 
   private ByteBuffer newKey() {

--- a/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
@@ -169,15 +169,7 @@ public class StandardEncryptionManager implements EncryptionManager {
       throw new IllegalStateException("Cannot unwrap key after serialization (missing KMS client)");
     }
 
-    WrappedEncryptionKey cachedKey = keyData.encryptionKeys.get(keyId);
-    ByteBuffer key = cachedKey.key();
-
-    if (key == null) {
-      key = unwrapKey(cachedKey.wrappedKey());
-      cachedKey.setUnwrappedKey(key);
-    }
-
-    return key;
+    return unwrapKey(keyData.encryptionKeys.get(keyId).wrappedKey());
   }
 
   Collection<WrappedEncryptionKey> keys() {
@@ -202,9 +194,7 @@ public class StandardEncryptionManager implements EncryptionManager {
 
   private void createNewEncryptionKey() {
     long now = System.currentTimeMillis();
-    ByteBuffer keyBytes = newKey();
-    WrappedEncryptionKey key =
-        new WrappedEncryptionKey(newKeyId(), keyBytes, wrapKey(keyBytes), now);
+    WrappedEncryptionKey key = new WrappedEncryptionKey(newKeyId(), wrapKey(newKey()), now);
     keyData.encryptionKeys.put(key.id(), key);
     keyData.currentEncryptionKey = key;
   }

--- a/core/src/main/java/org/apache/iceberg/encryption/WrappedEncryptionKey.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/WrappedEncryptionKey.java
@@ -25,10 +25,8 @@ public class WrappedEncryptionKey implements Serializable {
   private final String keyID;
   private final ByteBuffer wrappedKey;
   private final long timestamp;
-  private ByteBuffer keyBytes;
 
-  public WrappedEncryptionKey(
-      String keyID, ByteBuffer keyBytes, ByteBuffer wrappedKey, long timestamp) {
+  public WrappedEncryptionKey(String keyID, ByteBuffer wrappedKey, long timestamp) {
     this.keyID = keyID;
     this.wrappedKey = wrappedKey;
     this.timestamp = timestamp;
@@ -44,13 +42,5 @@ public class WrappedEncryptionKey implements Serializable {
 
   public long timestamp() {
     return timestamp;
-  }
-
-  public ByteBuffer key() {
-    return keyBytes;
-  }
-
-  public void setUnwrappedKey(ByteBuffer key) {
-    keyBytes = key;
   }
 }


### PR DESCRIPTION
This adds a Caffeine `LoadingCache` to `StandardEncryptionManager` to cache unwrapped keys. Unwrapped keys are only held in memory by the cache and temporarily by the caller that uses a key.

The first commit reverts the previous cache implementation.