### PR TITLE
Spec: Simplify changes needed for v3

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -982,12 +982,12 @@ The unified partition type looks like `Struct<field#1, field#2>`.
 
 Keys used for table encryption can be tracked in table metadata as a list named `encryption-keys`. The schema of each key is a struct with the following fields:
 
-| v1 | v2 |     v3     |     Field name        |   Type.              | Description |
-|----|----|------------|-----------------------|----------------------|-------------|
-|    |    | _required_ | **`key-id`**          | `string`             | ID of the encryption key |
-|    |    | _required_ | **`key-metadata`**.   | `string`             | Encrypted key and metadata, base64 encoded [1] |
-|    |    | _optional_ | **`encrypted-by-id`** | `string`             | Optional ID of the key used to encrypt or wrap `key-metadata` |
-|    |    | _optional_ | **`properties`**      | `map<string, string> | A string to string map of additional metadata used by the table's encryption scheme |
+| v1 | v2 |     v3     |     Field name               |   Type.              | Description |
+|----|----|------------|------------------------------|----------------------|-------------|
+|    |    | _required_ | **`key-id`**                 | `string`             | ID of the encryption key |
+|    |    | _required_ | **`encrypted-key-metadata`** | `string`             | Encrypted key and metadata, base64 encoded [1] |
+|    |    | _optional_ | **`encrypted-by-id`**        | `string`             | Optional ID of the key used to encrypt or wrap `key-metadata` |
+|    |    | _optional_ | **`properties`**             | `map<string, string> | A string to string map of additional metadata used by the table's encryption scheme |
 
 Notes:
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -982,12 +982,12 @@ The unified partition type looks like `Struct<field#1, field#2>`.
 
 Keys used for table encryption can be tracked in table metadata as a list named `encryption-keys`. The schema of each key is a struct with the following fields:
 
-| v1 | v2 |     v3     |     Field name          |   Type.              | Description |
-|----|----|------------|-------------------------|----------------------|-------------|
-|    |    | _required_ | **`key-id`**            | `string`             | ID of the encryption key |
-|    |    | _required_ | **`key-metadata`**.     | `string`             | Encrypted key and metadata, base64 encoded [1] |
-|    |    | _optional_ | **`encryption-key-id`** | `string`             | Optional ID of the key used to encrypt `key-metadata` |
-|    |    | _optional_ | **`properties`**        | `map<string, string> | A string to string map of additional metadata used by the table's encryption scheme |
+| v1 | v2 |     v3     |     Field name        |   Type.              | Description |
+|----|----|------------|-----------------------|----------------------|-------------|
+|    |    | _required_ | **`key-id`**          | `string`             | ID of the encryption key |
+|    |    | _required_ | **`key-metadata`**.   | `string`             | Encrypted key and metadata, base64 encoded [1] |
+|    |    | _optional_ | **`encrypted-by-id`** | `string`             | Optional ID of the key used to encrypt or wrap `key-metadata` |
+|    |    | _optional_ | **`properties`**      | `map<string, string> | A string to string map of additional metadata used by the table's encryption scheme |
 
 Notes:
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -1604,6 +1604,11 @@ Row-level delete changes:
     * These position delete files must be merged into the DV for a data file when one is created
     * Position delete files that contain deletes for more than one data file need to be kept in table metadata until all deletes are replaced by DVs
 
+Encryption changes:
+
+* Encryption keys are tracked by table metadata `encryption-keys`
+* The encryption key used for a snapshot is specified by `key-id`
+
 ### Version 2
 
 Writing v1 metadata:


### PR DESCRIPTION
This simplifies the changes from https://github.com/apache/iceberg/pull/12162 to minimize what we need to add to v3. It also fixes a couple of problems, like adding `key-id` to the `snapshot` table and changing the table metadata field to `encryption-keys`.

The main simplification is to reduce the scope to tracking encryption keys. Table metadata has `encryption-keys` and snapshots can specify a `key-id`. In addition, the requirements are relaxed to fit with any encryption scheme by allowing any payload for `key-metadata` and noting that the format is determined by the encryption scheme. It also calls out that the format of the key metadata may be specific to a KMS system.